### PR TITLE
Report active status when the charm is ready, waiting when a model is needed

### DIFF
--- a/reactive/kubeflow_tf_serving.py
+++ b/reactive/kubeflow_tf_serving.py
@@ -10,6 +10,12 @@ from charms.reactive import data_changed
 from charms import layer
 
 
+@when('charm.kubeflow-tf-serving.has-model')
+@when('charm.kubeflow-tf-serving.started')
+def charm_ready():
+    layer.status.active('')
+
+
 @when('config.changed.model')
 def update_model():
     clear_flag('charm.kubeflow-tf-serving.has-model')
@@ -37,6 +43,7 @@ def get_model():
     else:
         clear_flag('charm.kubeflow-tf-serving.has-model')
         unitdata.kv().unset('charm.kubeflow-tf-serving.model')
+        layer.status.waiting('waiting for model')
 
 
 @when('layer.docker-resource.tf-serving-image.available')


### PR DESCRIPTION
When charm has pushed the pod spec and a model is available, report status as active so juju can correctly reflect the unit status when the container has started.